### PR TITLE
GetPodMetrics batches pods to avoid excessive DFA states in queries

### DIFF
--- a/pkg/resourceprovider/provider.go
+++ b/pkg/resourceprovider/provider.go
@@ -178,7 +178,7 @@ func (p *resourceProvider) GetPodMetrics(pods ...*metav1.PartialObjectMetadata) 
 // It returns a map of namespace to batches of pod names. Batch size is hardcoded to 500.
 func batchPodsByNs(pods ...*metav1.PartialObjectMetadata) map[string][][]string {
 	batchSize := 500
-	podsByNsBatched := make(map[string][][]string, len(pods))
+	podsByNsBatched := map[string][][]string{}
 	for _, pod := range pods {
 		_, exists := podsByNsBatched[pod.Namespace]
 		if !exists {
@@ -236,7 +236,7 @@ func (p *resourceProvider) assignForPod(pod *metav1.PartialObjectMetadata, resul
 		}
 	}
 	// skip if any data is missing
-	if cpuRes == nil && memRes == nil {
+	if cpuRes == nil || memRes == nil {
 		if cpuRes == nil {
 			klog.Errorf("unable to fetch CPU metrics for pod %s in namespace %q, skipping", pod.String(), pod.Namespace)
 		}

--- a/pkg/resourceprovider/provider_test.go
+++ b/pkg/resourceprovider/provider_test.go
@@ -256,7 +256,7 @@ var _ = Describe("Resource Metrics Provider", func() {
 		))
 	})
 
-	It("should batch pods for queries by sets of size 500 each", func() {
+	It("should handle batching pods by sets of size 500 each, with a remainder", func() {
 		pods := make([]*metav1.PartialObjectMetadata, 1204)
 		for i := range pods {
 			if i%3 == 0 {
@@ -265,18 +265,77 @@ var _ = Describe("Resource Metrics Provider", func() {
 				pods[i] = &metav1.PartialObjectMetadata{ObjectMeta: metav1.ObjectMeta{Namespace: "other-ns", Name: fmt.Sprint(i)}}
 			}
 		}
-
 		podsByNsBatched := batchPodsByNs(pods...)
 
 		By("verifying that the pods have been grouped by namespace")
 		Expect(len(podsByNsBatched)).To(Equal(2))
 
-		By("verifying that the batches by namespace are in sets of 500")
+		By("verifying the batching counts per namespace")
 		Expect(podsByNsBatched["some-ns"]).To(HaveLen(1))
 		Expect(podsByNsBatched["some-ns"][0]).To(HaveLen(402))
 		Expect(podsByNsBatched["other-ns"]).To(HaveLen(2))
 		Expect(podsByNsBatched["other-ns"][0]).To(HaveLen(500))
 		Expect(podsByNsBatched["other-ns"][1]).To(HaveLen(302))
+	})
+
+	It("should handle batching pods by sets of size 500 each, with no remainder", func() {
+		pods := make([]*metav1.PartialObjectMetadata, 1000)
+		for i := range pods {
+			if i%2 == 0 {
+				pods[i] = &metav1.PartialObjectMetadata{ObjectMeta: metav1.ObjectMeta{Namespace: "some-ns", Name: fmt.Sprint(i)}}
+			} else {
+				pods[i] = &metav1.PartialObjectMetadata{ObjectMeta: metav1.ObjectMeta{Namespace: "other-ns", Name: fmt.Sprint(i)}}
+			}
+		}
+		podsByNsBatched := batchPodsByNs(pods...)
+
+		By("verifying that the pods have been grouped by namespace")
+		Expect(len(podsByNsBatched)).To(Equal(2))
+
+		By("verifying the batching counts per namespace")
+		Expect(podsByNsBatched["some-ns"]).To(HaveLen(1))
+		Expect(podsByNsBatched["some-ns"][0]).To(HaveLen(500))
+		Expect(podsByNsBatched["other-ns"]).To(HaveLen(1))
+		Expect(podsByNsBatched["other-ns"][0]).To(HaveLen(500))
+	})
+
+	It("should handle pods fitting in one batch per namespace", func() {
+		pods := []*metav1.PartialObjectMetadata{
+			{ObjectMeta: metav1.ObjectMeta{Namespace: "some-ns-1", Name: "pod1"}},
+			{ObjectMeta: metav1.ObjectMeta{Namespace: "some-ns-2", Name: "pod2"}},
+			{ObjectMeta: metav1.ObjectMeta{Namespace: "some-ns-3", Name: "pod3"}},
+		}
+		podsByNsBatched := batchPodsByNs(pods...)
+
+		By("verifying that the pods are in the first batch per namespace")
+		Expect(len(podsByNsBatched)).To(Equal(3))
+		Expect(podsByNsBatched["some-ns-1"]).To(HaveLen(1))
+		Expect(podsByNsBatched["some-ns-1"][0]).To(HaveLen(1))
+		Expect(podsByNsBatched["some-ns-1"][0][0]).To(Equal("pod1"))
+		Expect(podsByNsBatched["some-ns-2"]).To(HaveLen(1))
+		Expect(podsByNsBatched["some-ns-2"][0]).To(HaveLen(1))
+		Expect(podsByNsBatched["some-ns-2"][0][0]).To(Equal("pod2"))
+		Expect(podsByNsBatched["some-ns-3"]).To(HaveLen(1))
+		Expect(podsByNsBatched["some-ns-3"][0]).To(HaveLen(1))
+		Expect(podsByNsBatched["some-ns-3"][0][0]).To(Equal("pod3"))
+	})
+
+	It("should handle one pod in batching logic", func() {
+		pods := make([]*metav1.PartialObjectMetadata, 1)
+		pods[0] = &metav1.PartialObjectMetadata{ObjectMeta: metav1.ObjectMeta{Namespace: "some-ns", Name: "pod1"}}
+		podsByNsBatched := batchPodsByNs(pods...)
+
+		Expect(len(podsByNsBatched)).To(Equal(1))
+		Expect(podsByNsBatched["some-ns"]).To(HaveLen(1))
+		Expect(podsByNsBatched["some-ns"][0]).To(HaveLen(1))
+		Expect(podsByNsBatched["some-ns"][0][0]).To(Equal("pod1"))
+	})
+
+	It("should handle no pods in batching logic", func() {
+		pods := make([]*metav1.PartialObjectMetadata, 0)
+		podsByNsBatched := batchPodsByNs(pods...)
+
+		Expect(len(podsByNsBatched)).To(Equal(0))
 	})
 
 	It("should be able to list metrics for nodes", func() {


### PR DESCRIPTION
In high-volume namespace (1000s of pods), metrics queries fail due to excessive DFA states as a result of the `pod_name` label filter being generated as the regex `pod_name~=<pod1>|<pod2>|...|<podx>`. To circumvent this, we batch pods in batches of 500 per CPU/memory metrics query, and then aggregate the results at the end.

Added unit testing for the batching function.