### PR TITLE
Fix deadlock in GetPodMetrics batching logic

### DIFF
--- a/pkg/resourceprovider/provider.go
+++ b/pkg/resourceprovider/provider.go
@@ -136,7 +136,12 @@ func (p *resourceProvider) GetPodMetrics(pods ...*metav1.PartialObjectMetadata) 
 
 	// actually fetch the results for each batch in each namespace
 	now := pmodel.Now()
-	resChan := make(chan nsQueryResults, len(podsByNsBatched))
+	// create a buffered channel to store all results.
+	buffSize := 0
+	for _, batches := range podsByNsBatched {
+		buffSize += len(batches)
+	}
+	resChan := make(chan nsQueryResults, buffSize)
 
 	var wg sync.WaitGroup
 	for ns, batches := range podsByNsBatched {


### PR DESCRIPTION
Fixes deadlock in https://github.com/jodzga/prometheus-adapter/pull/1. 

Each batch calls `wg.Add(1)` and then must write to the results channel before signaling completion with `wg.Done()`. Note that we wait for all to complete with `wg.Wait()` before starting to read from the results channel. This means that the results channel must have a buffer of size at least the number of batches.

Otherwise, we are stuck in deadlock as all batches will not be able to write to the results channel before we read from the results channel, yet we are waiting for all to be written before proceeding to read from the results channel.