### PR TITLE
Add sev0 sev1 alerts for prom adapter errors

### DIFF
--- a/pkg/client/api.go
+++ b/pkg/client/api.go
@@ -90,6 +90,22 @@ func (c *httpAPIClient) Do(ctx context.Context, verb, endpoint string, query url
 
 	code := resp.StatusCode
 
+	// codes that are 4xx are bad request errors
+	if code >= 400 && code < 500 {
+		return APIResponse{}, &Error{
+			Type: ErrBadData,
+			Msg:  fmt.Sprintf("client error: %s", resp.Status),
+		}
+	}
+
+	// codes that are 5xx are bad server response errors
+	if code >= 500 && code < 600 {
+		return APIResponse{}, &Error{
+			Type: ErrBadResponse,
+			Msg:  fmt.Sprintf("server error: %s", resp.Status),
+		}
+	}
+
 	// codes that aren't 2xx, 400, 422, or 503 won't return JSON objects
 	if code/100 != 2 && code != 400 && code != 422 && code != 503 {
 		return APIResponse{}, &Error{

--- a/pkg/client/api.go
+++ b/pkg/client/api.go
@@ -93,7 +93,7 @@ func (c *httpAPIClient) Do(ctx context.Context, verb, endpoint string, query url
 	// codes that are 4xx are bad request errors
 	if code >= 400 && code < 500 {
 		return APIResponse{}, &Error{
-			Type: ErrBadData,
+			Type: ErrBadResponse,
 			Msg:  fmt.Sprintf("client error: %s", resp.Status),
 		}
 	}


### PR DESCRIPTION
### What type of PR is this?
This PR adds additional error responses for 4xx and 5xx responses from external metrics.


### What this PR does / why we need it:
We should have SEV0/SEV1 alerts on 400/500 error codes from the prom adapter metrics client. 
Prom Adapter is a critical dependency for HPA, and the errors would signal there is some critical issue fetching metrics for scaling from M3.

### Which issue(s) this PR fixes:

### Special notes for your reviewer:
### Does this PR introduce a user-facing change?

### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.: