### PR TITLE
safeguard against nil pointer dereference

### DIFF
--- a/pkg/client/api.go
+++ b/pkg/client/api.go
@@ -86,8 +86,16 @@ func (c *httpAPIClient) Do(ctx context.Context, verb, endpoint string, query url
 	}
 
 	resp, err := c.client.Do(req)
+	if resp == nil {
+		return APIResponse{}, &Error{
+			Type:       ErrExec,
+			Msg:        fmt.Sprintf("HTTP response is nil; error: %v", err),
+			StatusCode: 0, // No status code since no response
+			Query:      queryStr,
+		}
+	}
 	defer func() {
-		if resp != nil {
+		if resp != nil && resp.Body != nil {
 			resp.Body.Close()
 		}
 	}()

--- a/pkg/client/api.go
+++ b/pkg/client/api.go
@@ -91,7 +91,7 @@ func (c *httpAPIClient) Do(ctx context.Context, verb, endpoint string, query url
 		code = resp.StatusCode
 	}
 	defer func() {
-		if resp != nil && resp.Body != nil {
+		if resp != nil {
 			resp.Body.Close()
 		}
 	}()

--- a/pkg/client/api.go
+++ b/pkg/client/api.go
@@ -104,14 +104,6 @@ func (c *httpAPIClient) Do(ctx context.Context, verb, endpoint string, query url
 			Query:      queryStr,
 		}
 	}
-	if resp == nil {
-		return APIResponse{}, &Error{
-			Type:       ErrExec,
-			Msg:        "HTTP response is nil, but no error received",
-			StatusCode: code,
-			Query:      queryStr,
-		}
-	}
 
 	if klog.V(6).Enabled() {
 		klog.Infof("%s %s %s", verb, u.String(), resp.Status)

--- a/pkg/client/api.go
+++ b/pkg/client/api.go
@@ -107,7 +107,7 @@ func (c *httpAPIClient) Do(ctx context.Context, verb, endpoint string, query url
 	if resp == nil {
 		return APIResponse{}, &Error{
 			Type:       ErrExec,
-			Msg:        fmt.Sprintf("HTTP response is nil; error: %v", err),
+			Msg:        "HTTP response is nil, but no error received",
 			StatusCode: code,
 			Query:      queryStr,
 		}

--- a/pkg/client/api.go
+++ b/pkg/client/api.go
@@ -86,13 +86,9 @@ func (c *httpAPIClient) Do(ctx context.Context, verb, endpoint string, query url
 	}
 
 	resp, err := c.client.Do(req)
-	if resp == nil {
-		return APIResponse{}, &Error{
-			Type:       ErrExec,
-			Msg:        fmt.Sprintf("HTTP response is nil; error: %v", err),
-			StatusCode: 0, // No status code since no response
-			Query:      queryStr,
-		}
+	code := 0
+	if resp != nil {
+		code = resp.StatusCode
 	}
 	defer func() {
 		if resp != nil && resp.Body != nil {
@@ -104,7 +100,15 @@ func (c *httpAPIClient) Do(ctx context.Context, verb, endpoint string, query url
 		return APIResponse{}, &Error{
 			Type:       ErrExec,
 			Msg:        err.Error(),
-			StatusCode: resp.StatusCode,
+			StatusCode: code,
+			Query:      queryStr,
+		}
+	}
+	if resp == nil {
+		return APIResponse{}, &Error{
+			Type:       ErrExec,
+			Msg:        fmt.Sprintf("HTTP response is nil; error: %v", err),
+			StatusCode: code,
 			Query:      queryStr,
 		}
 	}
@@ -112,8 +116,6 @@ func (c *httpAPIClient) Do(ctx context.Context, verb, endpoint string, query url
 	if klog.V(6).Enabled() {
 		klog.Infof("%s %s %s", verb, u.String(), resp.Status)
 	}
-
-	code := resp.StatusCode
 
 	// codes that aren't 2xx, 400, 422, or 503 won't return JSON objects
 	if code/100 != 2 && code != 400 && code != 422 && code != 503 {


### PR DESCRIPTION
Noticed that errors were being caused due to nil pointer dereferences in the Do call of client/api.go

Further investigation suggested that the error was due to the resp of the API call being nil and still trying to obtain information (such as status code).

This change sets a default statusCode of 0, and updates it if the resp != nil. This ensures that there is no nil pointer dereference